### PR TITLE
Feat: support enter multi dev modes automatically from an url opened on browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "debugger"
   ],
   "activationEvents": [
-    "onStartupFinished"
+    "*"
   ],
   "extensionKind": [
     "workspace"
@@ -361,6 +361,10 @@
       {
         "command": "Nocalhost.clearServerCluster",
         "title": "Clear server cluster"
+      },
+      {
+        "command": "Nocalhost.autoStartDevMode",
+        "title": "Auto Start Dev"
       },
       {
         "command": "Nocalhost.run",

--- a/src/main/commands/AutoStartDevMode.ts
+++ b/src/main/commands/AutoStartDevMode.ts
@@ -1,0 +1,181 @@
+/**
+ * Support enter multi dev modes automatically.
+ */
+
+import * as vscode from "vscode";
+import * as yaml from "yaml";
+
+import host from "../host";
+import { appTreeView } from "../extension";
+import NocalhostAppProvider from "../appProvider";
+import { LocalCluster } from "../clusters";
+import { LocalClusterNode } from "../clusters/LocalCuster";
+import state from "../state";
+import { NOCALHOST } from "../constants";
+import { NocalhostRootNode } from "../nodes/NocalhostRootNode";
+import { BaseNocalhostNode } from "../nodes/types/nodeType";
+import { DevSpaceNode } from "../nodes/DevSpaceNode";
+import { RUN, DEBUG } from "../commands/constants";
+import { IKubeconfig } from "../ctl/nhctl";
+import logger from "../utils/logger";
+
+import ICommand from "./ICommand";
+import { AUTO_START_DEV_MODE } from "./constants";
+import registerCommand from "./register";
+
+type ConnectionInfoType = {
+  strKubeconfig: string;
+  namespace: string;
+};
+
+type DataType = {
+  connectionInfo: ConnectionInfoType;
+  application: string;
+  workloadType:
+    | "Deployment"
+    | "StatefuleSet"
+    | "DaemonSet"
+    | "Job"
+    | "CronJob"
+    | "Pod";
+  workload: string;
+  action: "run" | "debug";
+};
+
+export default class AutoStartDevModeCommand implements ICommand {
+  command: string = AUTO_START_DEV_MODE;
+  context: vscode.ExtensionContext;
+
+  constructor(context: vscode.ExtensionContext) {
+    this.context = context;
+    registerCommand(context, this.command, true, this.execCommand.bind(this));
+  }
+
+  async execCommand(data: DataType, appTreeProvider?: NocalhostAppProvider) {
+    const { connectionInfo, application, workloadType, workload, action } =
+      data;
+
+    host.showProgressing("Adding cluster...", async () => {
+      let { kubeconfig, clusterName } = await this.getKubeconfig(
+        connectionInfo
+      );
+
+      let newLocalCluster = await LocalCluster.appendLocalClusterByKubeConfig(
+        kubeconfig
+      );
+
+      if (newLocalCluster) {
+        await this.addNewCluster(newLocalCluster);
+      }
+
+      // Locate workload node in tree view.
+      const searchPath = [
+        clusterName,
+        connectionInfo.namespace,
+        application,
+        "Workloads",
+        workloadType + "s",
+        workload,
+      ];
+      const targetWorkloadNode: BaseNocalhostNode = await host.withProgress(
+        {
+          title: `Entering ${action} mode...`,
+          cancellable: true,
+        },
+        async (_, token) => {
+          const rootNode = Promise.resolve(
+            appTreeProvider as Pick<BaseNocalhostNode, "getChildren">
+          );
+          return this.locateWorkerloadNode(token, rootNode, searchPath);
+        }
+      );
+
+      // Reveal node in tree view.
+      const nodeStateId = state.getNode(targetWorkloadNode.getNodeStateId());
+      await appTreeView.reveal(nodeStateId);
+
+      // Enter different dev modes.
+      this.enterDevModes(action, targetWorkloadNode);
+    });
+  }
+
+  private enterDevModes(
+    action: "debug" | "run",
+    targetWorkloadNode: BaseNocalhostNode
+  ): void {
+    switch (action) {
+      case "run":
+        vscode.commands.executeCommand(RUN, targetWorkloadNode, {
+          isAutoMode: true,
+        }); // Enter dev mode.
+        break;
+
+      case "debug":
+        vscode.commands.executeCommand(DEBUG, targetWorkloadNode, {
+          isAutoMode: true,
+        }); // Enter debug mode.
+        break;
+
+      default:
+        break;
+    }
+  }
+
+  private async addNewCluster(clusterNode: LocalClusterNode) {
+    await LocalCluster.getLocalClusterRootNode(clusterNode);
+
+    const node = state.getNode(NOCALHOST) as NocalhostRootNode;
+
+    // Add Cluster
+    node && (await node.addCluster(clusterNode));
+
+    // Refresh UI
+    await state.refreshTree(true);
+
+    vscode.window.showInformationMessage("Success add cluster");
+  }
+
+  private async locateWorkerloadNode(
+    token: vscode.CancellationToken,
+    rootNode: any,
+    searchPath: string[]
+  ) {
+    return searchPath.reduce(async (parent, label) => {
+      if (token.isCancellationRequested) {
+        return null;
+      }
+
+      const children = await (await parent).getChildren();
+
+      const child = children.find((item: any) => {
+        if (item instanceof DevSpaceNode) {
+          return item.info.namespace === label.toLowerCase();
+        }
+        return item.label.toLowerCase() === label.toLowerCase();
+      });
+
+      return child;
+    }, rootNode);
+  }
+
+  private async getKubeconfig(data: {
+    strKubeconfig?: string;
+    namespace?: string;
+  }) {
+    const { strKubeconfig } = data;
+    let kubeconfig;
+
+    try {
+      kubeconfig = yaml.parse(strKubeconfig);
+    } catch (error) {
+      logger.error("getKubeconfig yaml parse", error);
+    }
+
+    const clusterName = kubeconfig?.clusters[0]?.name;
+
+    return {
+      kubeconfig: kubeconfig as IKubeconfig,
+      clusterName,
+    };
+  }
+}

--- a/src/main/commands/DebugCommand.ts
+++ b/src/main/commands/DebugCommand.ts
@@ -33,13 +33,22 @@ export default class DebugCommand implements ICommand {
   node: ControllerResourceNode;
   container: ContainerConfig;
   configuration: vscode.DebugConfiguration;
+  isAutoMode: boolean;
+
   constructor(context: vscode.ExtensionContext) {
     registerCommand(context, this.command, false, this.execCommand.bind(this));
   }
   async execCommand(...rest: any[]) {
     const [node, param] = rest as [
       ControllerResourceNode,
-      { command: string; configuration: vscode.DebugConfiguration } | undefined
+      (
+        | {
+            command: string;
+            configuration: vscode.DebugConfiguration;
+            isAutoMode: boolean;
+          }
+        | undefined
+      )
     ];
     if (!node) {
       host.showWarnMessage("Failed to get node configs, please try again.");
@@ -47,6 +56,7 @@ export default class DebugCommand implements ICommand {
     }
 
     this.configuration = param?.configuration;
+    this.isAutoMode = param?.isAutoMode || false;
     this.node = node;
     this.container = await getContainer(node);
 
@@ -59,6 +69,7 @@ export default class DebugCommand implements ICommand {
         vscode.commands.executeCommand(START_DEV_MODE, node, {
           command: DEBUG,
           configuration: this.configuration,
+          isAutoMode: this.isAutoMode,
         });
         return;
       }

--- a/src/main/commands/RunCommand.ts
+++ b/src/main/commands/RunCommand.ts
@@ -30,6 +30,7 @@ export default class RunCommand implements ICommand {
   container: ContainerConfig;
   isReload: boolean = false;
   terminal: RemoteTerminal;
+  isAutoMode: boolean;
 
   disposable: Array<{ dispose(): any }> = [];
 
@@ -40,7 +41,7 @@ export default class RunCommand implements ICommand {
   async execCommand(...rest: any[]) {
     const [node, param] = rest as [
       ControllerResourceNode,
-      { command: string } | undefined
+      { command: string; isAutoMode?: boolean } | undefined
     ];
 
     if (!node) {
@@ -50,6 +51,7 @@ export default class RunCommand implements ICommand {
 
     this.node = node;
     this.container = await getContainer(node);
+    this.isAutoMode = param?.isAutoMode || false;
 
     this.validateRunConfig(this.container);
 
@@ -59,6 +61,7 @@ export default class RunCommand implements ICommand {
       if (status !== "developing") {
         vscode.commands.executeCommand(START_DEV_MODE, node, {
           command: RUN,
+          isAutoMode: this.isAutoMode,
         });
         return;
       }

--- a/src/main/commands/constants.ts
+++ b/src/main/commands/constants.ts
@@ -65,3 +65,6 @@ export const ADD_KUBECONFIG = "Nocalhost.addKubeconfig";
 export const CLUSTERS_VIEW = "Nocalhost.ClustersView";
 
 export const CONFIG_URI_QUERY = "_configURIQuery";
+
+// Enter dev-modes(run | debug) automatically
+export const AUTO_START_DEV_MODE = "Nocalhost.autoStartDevMode";

--- a/src/main/commands/index.ts
+++ b/src/main/commands/index.ts
@@ -48,6 +48,7 @@ import ResumeProxyModeCommand from "./proxy/ResumeProxyModeCommand";
 import EndProxyModeCommand from "./proxy/EndProxyModeCommand";
 import HomeWebViewCommand from "./HomeWebViewCommand";
 import StartMeshDevModeCommand from "./StartMeshDevModeCommand";
+import AutoStartDevModeCommand from "./AutoStartDevMode";
 
 export default function initCommands(
   context: vscode.ExtensionContext,
@@ -115,4 +116,6 @@ export default function initCommands(
   new EndProxyModeCommand(context);
 
   new HomeWebViewCommand(context);
+
+  new AutoStartDevModeCommand(context);
 }


### PR DESCRIPTION
# Feat

Issue: https://github.com/nocalhost/nocalhost/issues/1334

Support enter `Remote Debug` and `Remote Run` dev modes automatically, by opening an `vscode:/xxx.xxx` style uri from developer's browser.

## Effect

Current behaviors of the plugin are not modified, the will still work as they should be.